### PR TITLE
Add global unique var

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,3 +14,6 @@
     name: supervisor
     state: restarted
   listen: "restart supervisor"
+
+- name: restart netbox
+  supervisorctl: name=netbox state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,4 +16,6 @@
   listen: "restart supervisor"
 
 - name: restart netbox
-  supervisorctl: name=netbox state=restarted
+  supervisorctl:
+    name: netbox 
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,9 @@
   template:
     src: configuration.py.j2
     dest: "{{ netbox_install_directory }}/netbox/netbox/netbox/configuration.py"
-  notify: "update netbox django"
+  notify:
+    - "update netbox django"
+    - "restart netbox"
 
 - name: ensure naplam is installed in virtualenv
   pip:

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -82,7 +82,7 @@ EMAIL = {
 
 # Enforcement of unique IP space can be toggled on a per-VRF basis. To enforce unique IP space within the global table
 # (all prefixes and IP addresses not assigned to a VRF), set ENFORCE_GLOBAL_UNIQUE to True.
-ENFORCE_GLOBAL_UNIQUE = False
+ENFORCE_GLOBAL_UNIQUE = {{ netbox_enforce_global_unique | default('False') }}
 
 # Enable custom logging. Please see the Django documentation for detailed guidance on configuring custom logs:
 #   https://docs.djangoproject.com/en/1.11/topics/logging/


### PR DESCRIPTION
This PR adds a variable so users can enable the configuration setting controlling enforcement of unique IP address space in the global VRF, as well as a handler to restart the netbox app via supervisorctl.